### PR TITLE
geocode when page is served from https

### DIFF
--- a/static/js/google_map.js
+++ b/static/js/google_map.js
@@ -33,7 +33,7 @@ function init() {
     var addresses = ['Ghent'];
 
     for (var x = 0; x < addresses.length; x++) {
-        $.getJSON('http://maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
+        $.getJSON('//maps.googleapis.com/maps/api/geocode/json?address='+addresses[x]+'&sensor=false', null, function (data) {
             var p = data.results[0].geometry.location
             var latlng = new google.maps.LatLng(p.lat, p.lng);
             new google.maps.Marker({


### PR DESCRIPTION
Google maps is now geo-coding correctly requested address even when page
is served from HTTPS.