### PR TITLE
Remove the Map JS if the map is disabled.

### DIFF
--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -14,6 +14,9 @@
 	<script src="js/jquery.magnific-popup.min.js"></script>
 	<script src="js/magnific-popup-options.js"></script>
 	<!-- Google Map -->
+	{{ if .Site.Params.contact.map }}
 	<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCefOgb1ZWqYtj7raVSmN4PL2WkTrc-KyA&sensor=false"></script>
 	<script src="js/google_map.js"></script>
+	{{ end }}
+	<!-- Main JavaScript -->
 	<script src="js/main.js"></script>


### PR DESCRIPTION
Remove the Google Map javaScript from the html page so the browser doesn't load it if the map is disabled.