### PR TITLE
Fix prepend and postpend navbar links

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -11,7 +11,7 @@
                   <ul class="nav navbar-nav navbar-right">
 
                     {{ range .Site.Menus.prepend }}
-                        <li><a href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
+                        <li><a class="external" href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
                     {{ end }}
 
                     <li class="active"><a href="#" data-nav-section="home"><span>{{ with .Site.Params.navigation.home }}{{ . | markdownify }}{{ end }}</span></a></li>
@@ -37,7 +37,7 @@
                     {{ end }}
 
                     {{ range .Site.Menus.postpend }}
-                        <li><a href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
+                        <li><a class="external" href="{{ .URL }}"><span>{{ .Name | markdownify }}</span></a></li>
                     {{ end }}
                 </ul>
             </div>


### PR DESCRIPTION
Left clicking on the prepended or postpended external links in the navbar was not working because of [this line](https://github.com/saey55/hugo-elate-theme/blob/master/static/js/main.js#L65) excluding links with the external class. Adding external class to both link tags fixed the issue.