### PR TITLE
Fix the unwanted header in contact form

### DIFF
--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,6 @@
 				</div>
 				{{ if .Site.Params.contact.form }}
 				<div class="col-md-6 to-animate">
-					<h3>{{ with .Site.Params.contact.form }}{{ . | markdownify }}{{ end }}</h3>
 					<form method="post" action="//formspree.io/{{ with .Site.Params.email }}{{.}}{{ end }}">
 					<div class="form-group ">
 						{{ with .Site.Params.contact.name }}


### PR DESCRIPTION
String 'true' is shown above the contact form as a header when the form is enabled, as shown below:

![The unwanted header](https://user-images.githubusercontent.com/12567035/37475430-01c0afcc-2873-11e8-8e3c-208aca780191.png)

 I suggest to delete the line which render it.