### PR TITLE
fix #37 add config key for Google Maps Javascript API Key

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,6 +12,10 @@ theme = "hugo-elate-theme"
   author = ""
   description = ""
   email = ""
+
+  # Google Maps Javascript API Key (if not set will default to not passing a key)
+  googleMapsApiKey = ""
+
   # Navigation
   [params.navigation]
     brand = "Elate"

--- a/layouts/partials/js.html
+++ b/layouts/partials/js.html
@@ -15,7 +15,11 @@
 	<script src="js/magnific-popup-options.js"></script>
 	<!-- Google Map -->
 	{{ if .Site.Params.contact.map }}
-	<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCefOgb1ZWqYtj7raVSmN4PL2WkTrc-KyA&sensor=false"></script>
+		{{ if .Site.Params.googleMapsApiKey }}
+		<script src="https://maps.googleapis.com/maps/api/js?key={{ .Site.Params.googleMapsApiKey }}"></script>
+		{{ else }}
+		<script src="https://maps.googleapis.com/maps/api/js"></script>
+		{{ end }}
 	<script src="js/google_map.js"></script>
 	{{ end }}
 	<!-- Main JavaScript -->


### PR DESCRIPTION
An API key is now required, see this issue: #37. 
Also, sensor param is not required, recommended to remove, see SensorNotRequired in https://developers.google.com/maps/documentation/javascript/error-messages#sensor-not-required