### PR TITLE
Formspree format has changed

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -12,6 +12,7 @@ theme = "hugo-elate-theme"
   author = ""
   description = ""
   email = ""
+  formspree = "" # https://formspree.io/f/XXXXXXXX
 
   # Google Maps Javascript API Key (if not set will default to not passing a key)
   googleMapsApiKey = ""

--- a/layouts/partials/contact.html
+++ b/layouts/partials/contact.html
@@ -21,7 +21,7 @@
 				</div>
 				{{ if .Site.Params.contact.form }}
 				<div class="col-md-6 to-animate">
-					<form method="post" action="//formspree.io/{{ with .Site.Params.email }}{{.}}{{ end }}">
+					<form method="post" action="{{ with .Site.Params.formspree }}{{.}}{{ end }}">
 					<div class="form-group ">
 						{{ with .Site.Params.contact.name }}
 						<label for="name" class="sr-only">{{ . | markdownify }}</label>


### PR DESCRIPTION
Formspree has chaned their link format from email to 8 character key.

The proposed change adds a 'formspree' param to config.toml, where you set your https://formspree.io/f/XXXXXXXX link.